### PR TITLE
feat: report unhandled query

### DIFF
--- a/modules.py
+++ b/modules.py
@@ -13,4 +13,9 @@ def reply(bot, message, intent, entities):
                        '\n' + random_comic.getExplanation(), parse_mode='Markdown',
                        reply_to_message_id=message.message_id, reply_markup=markup)
     else:
-        bot.reply_to(message, message.text)
+        title = "Add+new+module+"+message.text
+        body = message.text+"+module+not+present"
+        markup = telebot.types.InlineKeyboardMarkup()
+        markup.add(telebot.types.InlineKeyboardButton(text = 'Report', url = "https://github.com/the-vision/jarvis-telegram/issues/new?title="+title+"&body="+body))    
+        bot.send_message(message.chat.id,text="Sorry, this feature isn't available yet!", 
+                        parse_mode='Markdown', reply_to_message_id=message.message_id, reply_markup=markup)

--- a/modules.py
+++ b/modules.py
@@ -1,5 +1,6 @@
 from telebot import types
 
+import random
 import xkcd
 
 
@@ -12,10 +13,19 @@ def reply(bot, message, intent, entities):
                        random_comic.getTitle() + '*\n' + random_comic.getAltText() +
                        '\n' + random_comic.getExplanation(), parse_mode='Markdown',
                        reply_to_message_id=message.message_id, reply_markup=markup)
+    elif intent == 'hello':
+        greetings = [
+            'Hello there!',
+            'Hey!',
+            'Hi!',
+            'Oh hello!'
+        ]
+        greeting = random.choice(greetings)
+        bot.reply_to(message, greeting)
     else:
-        title = "Add+new+module+"+message.text
-        body = message.text+"+module+not+present"
-        markup = telebot.types.InlineKeyboardMarkup()
-        markup.add(telebot.types.InlineKeyboardButton(text = 'Report', url = "https://github.com/the-vision/jarvis-telegram/issues/new?title="+title+"&body="+body))    
-        bot.send_message(message.chat.id,text="Sorry, this feature isn't available yet!", 
-                        parse_mode='Markdown', reply_to_message_id=message.message_id, reply_markup=markup)
+        title = "Unhandled+query:+" + message.text
+        body = "What's+the+expected+result?+PLACEHOLDER_TEXT"
+        markup = types.InlineKeyboardMarkup()
+        markup.add(types.InlineKeyboardButton(text='Report', url="https://github.com/the-vision/jarvis-telegram/issues/new?title=" + title + "&body=" + body))
+        bot.send_message(message.chat.id, text="Sorry, this feature isn't available yet!",
+                         parse_mode='Markdown', reply_to_message_id=message.message_id, reply_markup=markup)


### PR DESCRIPTION
This PR closes #13 

Whenever the bot gets an unknown query, it provides an option to report it in GitHub:

![Screenshot from 2020-03-05 23-13-30](https://user-images.githubusercontent.com/42573842/76010165-79883b80-5f38-11ea-9af8-0abe6392a4cd.png)

When `Report` button is pressed, it is directed to the project's `issues` header, where pre-defined text helps non-technical users to report issue directly

![Screenshot from 2020-03-05 23-26-51](https://user-images.githubusercontent.com/42573842/76010400-d4219780-5f38-11ea-82c2-8979a5750156.png)
