### PR TITLE
feat: translate module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.vscode/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
-.vscode/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/modules.py
+++ b/modules.py
@@ -39,7 +39,7 @@ def reply(bot, message, intent, entities):
         bot.send_photo(message.chat.id, photo=coin_images[result],
                        reply_to_message_id=message.message_id)
     elif intent == 'translate':
-        word = entities[0][text]
+        word = entities[0]['text']
         markup = types.InlineKeyboardMarkup()
         markup.add(types.InlineKeyboardButton(text='Spanish', url="https://translate.google.co.in/#view=home&op=translate&sl=en&tl=es&text="+word)) 
         markup.add(types.InlineKeyboardButton(text='Japanese', url="https://translate.google.co.in/#view=home&op=translate&sl=en&tl=ja&text="+word)) 

--- a/modules.py
+++ b/modules.py
@@ -49,13 +49,19 @@ def reply(bot, message, intent, entities):
         bot.send_photo(message.chat.id, photo=coin_images[result],
                        reply_to_message_id=message.message_id)
     elif intent == 'translate':
-        word = entities[0]['text']
-        markup = types.InlineKeyboardMarkup()
-        markup.add(types.InlineKeyboardButton(text='Spanish', url="https://translate.google.co.in/#view=home&op=translate&sl=en&tl=es&text="+word)) 
-        markup.add(types.InlineKeyboardButton(text='Japanese', url="https://translate.google.co.in/#view=home&op=translate&sl=en&tl=ja&text="+word)) 
-        markup.add(types.InlineKeyboardButton(text='Russian', url="https://translate.google.co.in/#view=home&op=translate&sl=en&tl=ru&text="+word))      
-        bot.send_message(message.chat.id,text="Translate to :", parse_mode='Markdown',
-                       reply_to_message_id=message.message_id, reply_markup=markup)
+        try:
+            text = entities[0]['value']
+            response = requests.post('https://google-translate1.p.rapidapi.com/language/translate/v2', headers={
+                'x-rapidapi-key': RAPID_API_KEY,
+                'accept-encoding': 'application/gzip',
+                'content-type': 'application/x-www-form-urlencoded'
+            }, data='source=en&q=' + text + '&target=es')
+            data = response.json()
+            print(data)
+            bot.reply_to(message, 'Here is the Spanish translation: ' + data['data']['translations'][0]['translatedText'])
+        except Exception as e:
+            print(e)
+            bot.reply_to(message, 'I could not fetch the translation for you this time. Please try again later!')
     elif intent == 'dice':
         dice_images = {
             '1': 'https://www.ssaurel.com/blog/wp-content/uploads/2017/05/dice_1.png',

--- a/modules.py
+++ b/modules.py
@@ -38,12 +38,12 @@ def reply(bot, message, intent, entities):
         result = random.choice(['Heads', 'Tails'])
         bot.send_photo(message.chat.id, photo=coin_images[result],
                        reply_to_message_id=message.message_id)
-    elif intent[:9] == 'translate':
-        word = message.text[9:]
-        markup = telebot.types.InlineKeyboardMarkup()
-        markup.add(telebot.types.InlineKeyboardButton(text='Spanish', url="https://translate.google.co.in/#view=home&op=translate&sl=en&tl=es&text="+word)) 
-        markup.add(telebot.types.InlineKeyboardButton(text='Japanese', url="https://translate.google.co.in/#view=home&op=translate&sl=en&tl=ja&text="+word)) 
-        markup.add(telebot.types.InlineKeyboardButton(text='Russian', url="https://translate.google.co.in/#view=home&op=translate&sl=en&tl=ru&text="+word))      
+    elif intent == 'translate':
+        word = entities[0][text]
+        markup = types.InlineKeyboardMarkup()
+        markup.add(types.InlineKeyboardButton(text='Spanish', url="https://translate.google.co.in/#view=home&op=translate&sl=en&tl=es&text="+word)) 
+        markup.add(types.InlineKeyboardButton(text='Japanese', url="https://translate.google.co.in/#view=home&op=translate&sl=en&tl=ja&text="+word)) 
+        markup.add(types.InlineKeyboardButton(text='Russian', url="https://translate.google.co.in/#view=home&op=translate&sl=en&tl=ru&text="+word))      
         bot.send_message(message.chat.id,text="Translate to :", parse_mode='Markdown',
                        reply_to_message_id=message.message_id, reply_markup=markup)
     else:

--- a/modules.py
+++ b/modules.py
@@ -38,6 +38,14 @@ def reply(bot, message, intent, entities):
         result = random.choice(['Heads', 'Tails'])
         bot.send_photo(message.chat.id, photo=coin_images[result],
                        reply_to_message_id=message.message_id)
+    elif intent[:9] == 'translate':
+        word = message.text[9:]
+        markup = telebot.types.InlineKeyboardMarkup()
+        markup.add(telebot.types.InlineKeyboardButton(text='Spanish', url="https://translate.google.co.in/#view=home&op=translate&sl=en&tl=es&text="+word)) 
+        markup.add(telebot.types.InlineKeyboardButton(text='Japanese', url="https://translate.google.co.in/#view=home&op=translate&sl=en&tl=ja&text="+word)) 
+        markup.add(telebot.types.InlineKeyboardButton(text='Russian', url="https://translate.google.co.in/#view=home&op=translate&sl=en&tl=ru&text="+word))      
+        bot.send_message(message.chat.id,text="Translate to :", parse_mode='Markdown',
+                       reply_to_message_id=message.message_id, reply_markup=markup)
     else:
         title = "Unhandled+query:+" + message.text
         body = "What's+the+expected+result?+PLACEHOLDER_TEXT"


### PR DESCRIPTION
Closes #21 

Description:
* Since telegram doesn't provide a  to save the state of a user and since the project doesn't use any database, a workaround is to show the destination language, and then providing a URL to Google Translate with pre-filled and translated data.
![Screenshot from 2020-03-10 09-15-03](https://user-images.githubusercontent.com/42573842/76278308-5bf90000-62b1-11ea-8729-00d398020b88.png)
